### PR TITLE
Fixed UX for examples.

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 serde = { version = "1.0.132", features = ["rc"] }
-test-fuzz = { path = "../test-fuzz", version = "=2.0.0", default-features = false }
+test-fuzz = { path = "../test-fuzz", version = "=2.0.0" }
 
 [dev-dependencies]
 lazy_static = "1.4.0"


### PR DESCRIPTION
Signed-off-by: Aleksandr <a-p-petrosyan@yandex.ru>

Closes #80. 

# In-depth

The examples are supposed to be out-of-the-box working code, that people use to test if they have an incorrect (or incompatible) set up. The correct UX is that the examples should showcase the defaults, and work without modifications. 