### PR TITLE
Fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ At a high-level, `test-fuzz` is a convenient front end for [`afl.rs`](https://gi
 Install `cargo-test-fuzz` and [`afl.rs`](https://github.com/rust-fuzz/afl.rs) with the following command:
 
 ```sh
-cargo install cargo-test-fuzz afl
+cargo install cargo-test-fuzz cargo-afl
 ```
 
 ## Usage


### PR DESCRIPTION
The afl crate is just a library crate. Probably even empty.