### PR TITLE
Add support for generating coverage

### DIFF
--- a/cargo-test-fuzz/src/bin/cargo_test_fuzz/transition.rs
+++ b/cargo-test-fuzz/src/bin/cargo_test_fuzz/transition.rs
@@ -37,6 +37,8 @@ struct TestFuzzWithDeprecations {
     consolidate: bool,
     #[arg(long, hide = true)]
     consolidate_all: bool,
+    #[arg(long, hide = true)]
+    coverage: bool,
     #[arg(
         long,
         value_name = "OBJECT",
@@ -131,6 +133,7 @@ impl From<TestFuzzWithDeprecations> for super::TestFuzz {
             backtrace,
             consolidate,
             consolidate_all,
+            coverage,
             display,
             exact,
             exit_code,
@@ -159,6 +162,7 @@ impl From<TestFuzzWithDeprecations> for super::TestFuzz {
             backtrace,
             consolidate,
             consolidate_all,
+            coverage,
             display,
             exact,
             exit_code,

--- a/cargo-test-fuzz/src/lib.rs
+++ b/cargo-test-fuzz/src/lib.rs
@@ -11,27 +11,12 @@ use cargo_metadata::{
 };
 use clap::{crate_version, ValueEnum};
 use heck::ToKebabCase;
-use internal::dirs::{
-    concretizations_directory_from_target, corpus_directory_from_target,
-    crashes_directory_from_target, hangs_directory_from_target,
-    impl_concretizations_directory_from_target, output_directory_from_target,
-    queue_directory_from_target, target_directory,
-};
+use internal::dirs::{concretizations_directory_from_target, corpus_directory_from_target, crashes_directory_from_target, hangs_directory_from_target, impl_concretizations_directory_from_target, output_directory_from_target, queue_directory_from_target, target_directory, workspace_root};
 use log::debug;
 use semver::Version;
 use semver::VersionReq;
 use serde::{Deserialize, Serialize};
-use std::{
-    ffi::OsStr,
-    fmt::{Debug, Formatter},
-    fs::{create_dir_all, read, read_dir, remove_dir_all, File},
-    io::{BufRead, Read},
-    iter,
-    path::{Path, PathBuf},
-    process::{exit, Command},
-    sync::Mutex,
-    time::Duration,
-};
+use std::{ffi::OsStr, fmt::{Debug, Formatter}, fs::{create_dir_all, read, read_dir, remove_dir_all, File}, fs, io::{BufRead, Read}, io, iter, path::{Path, PathBuf}, process::{exit, Command}, sync::Mutex, time::Duration};
 use strum_macros::Display;
 use subprocess::{CommunicateError, Exec, ExitStatus, NullFile, Redirection};
 
@@ -71,6 +56,7 @@ pub struct TestFuzz {
     pub backtrace: bool,
     pub consolidate: bool,
     pub consolidate_all: bool,
+    pub coverage: bool,
     pub display: Option<Object>,
     pub exact: bool,
     pub exit_code: bool,
@@ -161,7 +147,7 @@ pub fn run(opts: TestFuzz) -> Result<()> {
 
     let replay = opts.replay.is_some();
 
-    let executables = build(&opts, display || replay)?;
+    let executables = build(&opts, display || replay, opts.coverage)?;
 
     let mut executable_targets = executable_targets(&executables)?;
 
@@ -196,6 +182,10 @@ pub fn run(opts: TestFuzz) -> Result<()> {
         return reset(&opts, &executable_targets);
     }
 
+    if opts.coverage {
+        remove_profraw_files(target_directory(false))?;
+    }
+
     let (flags, dir) = None
         .or_else(|| {
             opts.display
@@ -208,8 +198,32 @@ pub fn run(opts: TestFuzz) -> Result<()> {
         .unwrap_or((Flags::empty(), PathBuf::default()));
 
     if display || replay {
-        return for_each_entry(&opts, &executable, &target, display, replay, flags, &dir);
+        let result =  for_each_entry(&opts, &executable, &target, display, replay, flags, &dir, opts.coverage);
+        if opts.coverage {
+            return match result {
+                Ok(_) => {
+                    let mut exec = Exec::cmd("cargo-llvm-cov")
+                        .args(
+                            &["llvm-cov", "report", "--profile", "debug", "--html", "--hide-instantiations", "-v", "--ignore-filename-regex", "test-fuzz"]
+                        )
+                        .env("CARGO_LLVM_COV", "1")
+                        .env("CARGO_LLVM_COV_SHOW_ENV", "1")
+                        .env("CARGO_LLVM_COV_TARGET_DIR", target_directory(false))
+                        .stdout(Redirection::Pipe);
+                    debug!("{:?}", exec);
+                    let mut popen = exec.clone().popen()?;
+                    println!("{:?}", popen.stdout);
+                    popen.wait(); // TODO Handle
+                    Ok(())
+                }
+                Err(e) => Err(e)
+            }
+        }
+
+        return result;
     }
+
+
 
     if opts.no_instrumentation {
         eprintln!("Stopping before fuzzing since --no-instrumentation was specified.");
@@ -225,7 +239,25 @@ pub fn run(opts: TestFuzz) -> Result<()> {
     })
 }
 
-fn build(opts: &TestFuzz, quiet: bool) -> Result<Vec<Executable>> {
+fn remove_profraw_files(dir: PathBuf) -> io::Result<()> {
+    if dir.is_dir() {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_file() {
+                if let Some(extension) = path.extension() {
+                    if extension == "profraw" {
+                        println!("{:?}", &path);
+                        fs::remove_file(path)?;
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn build(opts: &TestFuzz, quiet: bool, coverage: bool) -> Result<Vec<Executable>> {
     let metadata = metadata(opts)?;
 
     let mut args = vec![];
@@ -272,8 +304,18 @@ fn build(opts: &TestFuzz, quiet: bool) -> Result<Vec<Executable>> {
     if quiet && !opts.verbose {
         exec = exec.stderr(NullFile);
     }
+
+    let mut envs = Vec::new();
+    let target_dir = target_directory(false);
+    let workspace = workspace_root(); // TODO
+    let profraws = target_dir.join("examples-%p-%8m.profraw");
+
+    if coverage {
+        //envs.push(("LLVM_PROFILE_FILE", profraws.to_str().unwrap()));
+        envs.push(("RUSTFLAGS", "-C instrument-coverage --cfg=coverage --cfg=trybuild_no_target"));
+    }
     debug!("{:?}", exec);
-    let mut popen = exec.clone().popen()?;
+    let mut popen = exec.clone().env_extend(&envs).clone().popen()?;
     let artifacts = popen
         .stdout
         .take()
@@ -298,7 +340,7 @@ fn build(opts: &TestFuzz, quiet: bool) -> Result<Vec<Executable>> {
     // smoelius: If the command failed, re-execute it without --message-format=json. This is easier
     // than trying to capture and colorize `CompilerMessage`s like Cargo does.
     if !status.success() {
-        let mut popen = Exec::cmd("cargo").args(&args).popen()?;
+        let mut popen = Exec::cmd("cargo").args(&args).env_extend(&envs).popen()?;
         let status = popen
             .wait()
             .with_context(|| format!("`wait` failed for `{popen:?}`"))?;
@@ -434,10 +476,15 @@ fn executable_targets(executables: &[Executable]) -> Result<Vec<(Executable, Vec
 }
 
 fn targets(executable: &Path) -> Result<Vec<String>> {
-    let exec = Exec::cmd(executable)
+    let profraws = target_directory(false).join("ignore-%p-%8m.profraw");
+
+    let mut exec = Exec::cmd(executable)
         .env_extend(&[("AFL_QUIET", "1")])
         .args(&["--list"])
         .stderr(NullFile);
+
+    exec = exec.env("LLVM_PROFILE_FILE", profraws.to_str().unwrap());
+
     debug!("{:?}", exec);
     let stream = exec.clone().stream_stdout()?;
 
@@ -716,6 +763,13 @@ fn flags_and_dir(object: Object, krate: &str, target: &str) -> (Flags, PathBuf) 
     }
 }
 
+fn get_last_component(path: &PathBuf) -> Option<String> {
+    path.components()
+        .filter(|comp| comp.as_os_str() != OsStr::new(""))
+        .map(|comp| comp.as_os_str().to_str().unwrap().to_owned())
+        .last()
+}
+
 #[allow(clippy::too_many_lines)]
 fn for_each_entry(
     opts: &TestFuzz,
@@ -725,6 +779,7 @@ fn for_each_entry(
     replay: bool,
     flags: Flags,
     dir: &Path,
+    coverage: bool
 ) -> Result<()> {
     ensure!(
         dir.exists(),
@@ -750,6 +805,13 @@ fn for_each_entry(
     }
     if opts.pretty_print {
         envs.push(("TEST_FUZZ_PRETTY_PRINT", "1"));
+    }
+
+    let target_dir = target_directory(false);
+    let workspace = get_last_component(&workspace_root()).unwrap();
+    let profraws = target_dir.join(format!("{workspace}-%p-%8m.profraw"));
+    if coverage {
+        envs.push(("LLVM_PROFILE_FILE", profraws.to_str().unwrap()));
     }
 
     let args: Vec<String> = vec![

--- a/internal/src/dirs.rs
+++ b/internal/src/dirs.rs
@@ -83,6 +83,12 @@ pub fn target_directory(instrumented: bool) -> PathBuf {
     }
     target_dir.into()
 }
+#[must_use]
+pub fn workspace_root() -> PathBuf {
+    let mut command = MetadataCommand::new();
+    let mut workspace_root = command.no_deps().exec().unwrap().workspace_root;
+    workspace_root.into()
+}
 
 #[must_use]
 fn path_from_args_type<T>() -> String {


### PR DESCRIPTION
This adds experimental support for generating coverage using LLVM and `cargo-llvm-cov`. Note that replacing `cargo-llvm-cov` would be simple. It might simplify stuff even as `cargo-llvm-cov` basically just invokes `llvm-profdata` and `llvm-cov`.

## How to use

Suppose you have a setup like in the `examples` directory of the repository. Then:

1. Install cargo-llvm-cov: `cargo install cargo-llvm-cov`
2. Install LLVM tools (they might get installed by cargo-llvm-cov automatically, we need to test that): `rustup toolchain install nightly --component llvm-tools-preview`
1. Run `cargo test`
3. Optionally, fuzz the project.
4. Execute `cargo-test-fuzz test-fuzz target --no-instrumentation --replay corpus --coverage`

Coverage is generated as HTML in `target/llvm-cov/html`.

### TODO:
* Should --coverage imply --no-instrumentation?
* Should --coverage be compatible with fuzzing? (probably not, even though it might just work)
* Make sure that `llvm-tools-preview` and `cargo-llvm-cov` get installed or promt for installation.
* On macOS I get the following warning during generation: `warning: 4 functions have mismatched data`

### Details

The follwing commands are executes to generate coverage. We should validate them:

```
     Running `/Users/max/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-profdata merge -sparse -f /Users/max/projects/examples/target/examples-profraw-list -o /Users/max/projects/examples/target/examples.profdata`
     Running `/Users/max/.rustup/toolchains/stable-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/bin/llvm-cov show -format=html -instr-profile=/Users/max/projects/examples/target/examples.profdata -object target/debug/deps/alloc-34551e9cc1ff6b3f -object target/debug/deps/arc-bf8fdeaeed680770 -object target/debug/deps/assert-ba6618cd737ff666 -object target/debug/deps/associated_type-7ed59268473251eb -object target/debug/deps/auto_concretize_0-736514e466198bc3 -object target/debug/deps/auto_generate-7287f7108f5b00a9 -object target/debug/deps/conversion-c5a93588844a6594 -object target/debug/deps/debug-ff5617e8189a0951 -object target/debug/deps/default-79bdc830b898ec0f -object target/debug/deps/from-2bc06bf9dd96fea9 -object target/debug/deps/generic-23602c4ce1352038 -object target/debug/deps/hello_world-594474f770d22b32 -object target/debug/deps/hello_world-cff0c92d5749ded3 -object target/debug/deps/lifetime-f34199c00924285b -object target/debug/deps/manual_leak-7a7f8bfdea2a3f10 -object target/debug/deps/mut_ref-295c3cd2737a4d53 -object target/debug/deps/parse_duration-d93f2ce3d20bd782 -object target/debug/deps/qwerty-72231f74eb29ea0a -object target/debug/deps/rename-503984417115eb3f -object target/debug/deps/return_type-3b4f1b217dc76985 -object target/debug/deps/serde-26f50433033e3e5d -object target/debug/deps/test_fuzz_impl-2a426bdf99ecc53a -object target/debug/deps/unserde-4a2d01352b369939 -object target/debug/hello-world -ignore-filename-regex 'test-fuzz|/rustc/([0-9a-f]+|[0-9]+\.[0-9]+\.[0-9]+)/|^/Users/max/projects/examples(/.*)?/(tests|examples|benches)/|^/Users/max/projects/examples/target($|/)|^/Users/max/\.cargo/(registry|git)/|^/Users/max/\.rustup/toolchains($|/)' -show-instantiations=false -show-line-counts-or-regions -show-expansions -show-branches=count -Xdemangler=/Users/max/.cargo/bin/cargo-llvm-cov -Xdemangler=llvm-cov -Xdemangler=demangle -output-dir=/Users/max/projects/examples/target/llvm-cov/html`
```