### PR TITLE
Use `fast` power schedule

### DIFF
--- a/cargo-test-fuzz/src/lib.rs
+++ b/cargo-test-fuzz/src/lib.rs
@@ -927,6 +927,8 @@ fn fuzz(opts: &TestFuzz, executable: &Executable, target: &str) -> Result<()> {
             "-D",
             "-M",
             "default",
+            "-p",
+            "fast",
         ]
         .into_iter()
         .map(String::from),


### PR DESCRIPTION
Reference: https://aflplus.plus/docs/power_schedules/

AFL++ 4.10c made `EXPLORE` the default power schedule: https://github.com/AFLplusplus/AFLplusplus/blob/602eceed8b56eef62d673a54b6011541bf1ab60a/docs/Changelog.md?plain=1#L8-L9

Around the same time, I started noticing CI failing.