### PR TITLE
Fix error message that is printed when multiple Serde formats are selected

### DIFF
--- a/internal/src/serde_format.rs
+++ b/internal/src/serde_format.rs
@@ -23,7 +23,6 @@ pub fn as_feature() -> &'static str {
 
     assert!(
         formats.len() <= 1,
-        "{}",
         "Multiple serde formats selected: {formats:?}"
     );
 


### PR DESCRIPTION
Found by Clippy's `literal_string_with_formatting_args` lint: https://rust-lang.github.io/rust-clippy/master/index.html#literal_string_with_formatting_args