### PR TITLE
Fix parallel fuzzing premature termination

### DIFF
--- a/cargo-test-fuzz/src/lib.rs
+++ b/cargo-test-fuzz/src/lib.rs
@@ -999,24 +999,24 @@ fn fuzz(opts: &TestFuzz, executable_targets: &[(Executable, String)]) -> Result<
         .map(|()| None::<Child>)
         .collect::<Vec<_>>();
     let mut i_target_prev = executable_targets.len();
-    
+
     // Track failed targets to detect when all targets fail
     let mut failed_targets = std::collections::HashSet::new();
-    
+
     loop {
         // If all targets have failed, terminate gracefully
         if failed_targets.len() == executable_targets.len() {
             eprintln!("All targets failed to start. Terminating fuzzing process.");
             break;
         }
-            
+
         if n_children < n_cpus && (i_task < executable_targets.len() || !config.sufficient_cpus) {
             let Some((executable, target)) = executable_targets_iter.next() else {
                 unreachable!();
             };
 
             let i_target = i_task % executable_targets.len();
-            
+
             // Skip targets that have already failed
             if failed_targets.contains(&i_target) {
                 i_task += 1;
@@ -1109,7 +1109,10 @@ fn fuzz(opts: &TestFuzz, executable_targets: &[(Executable, String)]) -> Result<
                     .with_context(|| format!("`wait` failed for `{:?}`", child.popen))?;
 
                 if !status.success() {
-                    eprintln!("Warning: Command failed for target {}: {:?}", target, child.exec);
+                    eprintln!(
+                        "Warning: Command failed for target {}: {:?}",
+                        target, child.exec
+                    );
                     failed_targets.insert(i_target);
                     continue;
                 }


### PR DESCRIPTION
This PR addresses issue #525 where parallel fuzzing terminates prematurely when a target fails.

## Problem
When fuzzing a target fails (e.g., due to missing corpus entries or crashes), the current implementation causes the entire parallel fuzzing process to stop, preventing other valid targets from being fuzzed.

## Solution
As suggested in the issue discussion, I've implemented a solution that:

1. **Continues Past Errors**: When a fuzzing target fails, the implementation now:
   - Logs a warning with specific target information
   - Marks the target as failed
   - Continues fuzzing the remaining valid targets

2. **Handles All-Targets-Failed**: To address the corner case mentioned:
   - Tracks failed targets in a HashSet
   - Detects when all targets have failed
   - Terminates gracefully with an informative message
   - Prevents spinning without making progress

This implementation focuses specifically on handling failures in the fuzzing targets themselves rather than system-level errors, as recommended in the review.