### PR TITLE
Remove unused `env` import in transition.rs

### DIFF
--- a/cargo-test-fuzz/src/bin/cargo_test_fuzz/transition.rs
+++ b/cargo-test-fuzz/src/bin/cargo_test_fuzz/transition.rs
@@ -2,7 +2,7 @@ use super::Object;
 use anyhow::Result;
 use clap::{crate_version, ArgAction, Parser};
 use serde::{Deserialize, Serialize};
-use std::{env, ffi::OsStr};
+use std::ffi::OsStr;
 
 #[derive(Debug, Parser)]
 #[command(bin_name = "cargo")]


### PR DESCRIPTION
### Description
This PR addresses issue #541 by removing the unused `env` import from the `std` module in the `cargo-test-fuzz/src/bin/cargo_test_fuzz/transition.rs` file.

## Changes Made
Modified line 5 from:
```rust
use std::{env, ffi::OsStr};
```

To:
```rust
use std::ffi::OsStr;
```

## Verification
- Compiled the project to confirm that no compilation errors were introduced
- Ran existing tests to ensure functionality remains unaffected
- Verified that no "unused import" warnings are generated after the change

## Issue Fixed
This PR resolves issue #541 by removing the unused import, improving code quality and reducing unnecessary imports.

## Additional Notes
The `env` import was previously declared but not referenced anywhere in the file. Removing it maintains the same functionality while improving code cleanliness.
