### PR TITLE
Add module-level documentation to lib.rs

### DIFF
--- a/cargo-test-fuzz/src/lib.rs
+++ b/cargo-test-fuzz/src/lib.rs
@@ -179,6 +179,7 @@ pub fn run(opts: TestFuzz) -> Result<()> {
     })
 }
 
+#[doc(hidden)]
 pub fn run_without_exit_code(opts: &TestFuzz, use_instrumentation: bool) -> Result<()> {
     if let Some(object) = opts.replay {
         ensure!(

--- a/cargo-test-fuzz/src/lib.rs
+++ b/cargo-test-fuzz/src/lib.rs
@@ -1,21 +1,16 @@
 //! # cargo-test-fuzz
 //!
-//! This crate provides the core functionality for the `cargo-test-fuzz` command line tool, which
-//! integrates with Rust's testing framework to automate tasks related to fuzzing with `afl.rs`.
+//! This crate provides the implementation for the `cargo test-fuzz` subcommand.
 //!
-//! The primary features of this crate include:
+//! ## Primary Exports
 //!
-//! - Building and running fuzz tests using `afl.rs`
-//! - Managing and generating fuzzing corpora
-//! - Displaying and replaying crashes and hangs
-//! - Consolidating and resetting test output
+//! - [`run`](fn.run.html): The main entry point function for executing fuzzing operations
+//! - [`TestFuzz`](struct.TestFuzz.html): Configuration struct containing all fuzzing options
+//! - [`Object`](enum.Object.html): Enum representing different types of fuzzing artifacts
 //!
-//! This crate provides the backend for the `cargo test-fuzz` subcommand, which allows users to:
-//! - Run fuzzing operations against test targets annotated with the `test_fuzz` macro
-//! - Manage fuzzing artifacts (corpus, crashes, hangs)
-//! - Configure fuzzing parameters (timeout, CPU usage, etc.)
+//! For more information on `test-fuzz`, see the project's [README].
 //!
-//! For more information on usage, see the README and documentation for the `test-fuzz` project.
+//! [README]: https://github.com/trailofbits/test-fuzz/blob/master/README.md
 
 #![deny(clippy::expect_used)]
 #![deny(clippy::unwrap_used)]

--- a/cargo-test-fuzz/src/lib.rs
+++ b/cargo-test-fuzz/src/lib.rs
@@ -1,3 +1,22 @@
+//! # cargo-test-fuzz
+//!
+//! This crate provides the core functionality for the `cargo-test-fuzz` command line tool, which
+//! integrates with Rust's testing framework to automate tasks related to fuzzing with `afl.rs`.
+//!
+//! The primary features of this crate include:
+//!
+//! - Building and running fuzz tests using `afl.rs`
+//! - Managing and generating fuzzing corpora
+//! - Displaying and replaying crashes and hangs
+//! - Consolidating and resetting test output
+//!
+//! This crate provides the backend for the `cargo test-fuzz` subcommand, which allows users to:
+//! - Run fuzzing operations against test targets annotated with the `test_fuzz` macro
+//! - Manage fuzzing artifacts (corpus, crashes, hangs)
+//! - Configure fuzzing parameters (timeout, CPU usage, etc.)
+//!
+//! For more information on usage, see the README and documentation for the `test-fuzz` project.
+
 #![deny(clippy::expect_used)]
 #![deny(clippy::unwrap_used)]
 #![warn(clippy::panic)]


### PR DESCRIPTION
## Description
This PR addresses issue #543 by adding comprehensive module-level documentation to the main library file `cargo-test-fuzz/src/lib.rs`. The documentation provides an overview of the crate's purpose, its primary features, and how it integrates with the larger `test-fuzz` project.

## Changes
- Added a module-level documentation block using `//!` doc comments at the beginning of the file
- Included information about the crate's core functionality and features
- Explained how the crate relates to the `cargo test-fuzz` subcommand

## Related Issue
Closes #543

## Checklist
- [x] Documentation added
- [x] Code follows project style and conventions
- [x] Changes don't break existing functionality