### PR TITLE
Remove `markdown-link-check` from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,6 @@ jobs:
       - name: Prettier
         run: npm install -g prettier && prettier --check '**/*.json' '**/*.md' '**/*.yml'
 
-      # smoelius: Pin `markdown-link-check` to version 3.11 until the following issue is resolved:
-      # https://github.com/tcort/markdown-link-check/issues/304
-      - name: Markdown link check
-        run: npm install -g markdown-link-check@3.11 && markdown-link-check ./**/*.md
-
       # https://github.com/DevinR528/cargo-sort/issues/57#issuecomment-1457714872
       - name: Cargo sort
         run: |


### PR DESCRIPTION
Now that #559 is merged.