### PR TITLE
Added integration test for Format checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,7 @@ jobs:
         run: |
           rustup install nightly
           rustup +nightly component add clippy
+          rustup +nightly component add rustfmt
           cargo install cargo-dylint dylint-link || true
           cargo install cargo-license            || true
           cargo install cargo-sort               || true

--- a/test-fuzz/tests/integration/ci.rs
+++ b/test-fuzz/tests/integration/ci.rs
@@ -23,6 +23,15 @@ fn clippy() {
 }
 
 #[test]
+fn format() {
+    Command::new("cargo")
+        .args(["+nightly", "fmt", "--check"])
+        .current_dir("..")
+        .logged_assert()
+        .success();
+}
+
+#[test]
 fn dylint() {
     Command::new("cargo")
         .args(["dylint", "--all", "--", "--all-targets"])


### PR DESCRIPTION
This PR partially addresses #413 by converting format check in rust.


*   **`format` Test:** Added `test-fuzz/tests/integration/ci.rs#format()` which runs `cargo +nightly fmt --check` in the workspace root to verify code formatting.
