### PR TITLE
Move `CARGO_AFL_VERSION` into `cached_cargo_afl_version`

### DIFF
--- a/cargo-test-fuzz/src/lib.rs
+++ b/cargo-test-fuzz/src/lib.rs
@@ -703,11 +703,11 @@ fn check_test_fuzz_and_afl_versions(
 }
 
 fn cached_cargo_afl_version() -> &'static Version {
+    static CARGO_AFL_VERSION: OnceLock<Version> = OnceLock::new();
+
     #[allow(clippy::unwrap_used)]
     CARGO_AFL_VERSION.get_or_init(|| cargo_afl_version().unwrap())
 }
-
-static CARGO_AFL_VERSION: OnceLock<Version> = OnceLock::new();
 
 fn cargo_afl_version() -> Result<Version> {
     #[allow(clippy::disallowed_methods)]


### PR DESCRIPTION
`cached_cargo_afl_version` is the only function that uses it.